### PR TITLE
Migrate KinesisProxy to ListShardsWithFilter for empty lease table case

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/EmptyLeaseTableSynchronizer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/EmptyLeaseTableSynchronizer.java
@@ -1,0 +1,84 @@
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import com.amazonaws.services.kinesis.clientlibrary.types.ExtendedSequenceNumber;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+import com.amazonaws.services.kinesis.leases.impl.Lease;
+import com.amazonaws.services.kinesis.model.Shard;
+import lombok.AllArgsConstructor;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisShardSyncer.StartingSequenceNumberAndShardIdBasedComparator;
+
+/**
+ * Class to help create leases when the table is initially empty.
+ */
+@AllArgsConstructor
+class EmptyLeaseTableSynchronizer implements LeaseSynchronizer {
+
+    private static final Log LOG = LogFactory.getLog(EmptyLeaseTableSynchronizer.class);
+
+    /**
+     * Determines how to create leases when the lease table is initially empty. For this, we read all shards where
+     * the KCL is reading from. For any shards which are closed, we will discover their child shards through GetRecords
+     * child shard information.
+     *
+     * @param shards
+     * @param currentLeases
+     * @param initialPosition
+     * @param inconsistentShardIds
+     * @return
+     */
+    @Override
+    public List<KinesisClientLease> determineNewLeasesToCreate(List<Shard> shards,
+                                                               List<KinesisClientLease> currentLeases,
+                                                               InitialPositionInStreamExtended initialPosition,
+                                                               Set<String> inconsistentShardIds) {
+
+        final Map<String, Shard> shardIdToShardMapOfAllKinesisShards =
+                KinesisShardSyncer.constructShardIdToShardMap(shards);
+
+        currentLeases.forEach(lease -> LOG.debug("Existing lease: " + lease.getLeaseKey()));
+
+        final List<KinesisClientLease> newLeasesToCreate =
+                getLeasesToCreateForOpenAndClosedShards(initialPosition, shards);
+
+        final Comparator<KinesisClientLease> startingSequenceNumberComparator =
+                new StartingSequenceNumberAndShardIdBasedComparator(shardIdToShardMapOfAllKinesisShards);
+
+        newLeasesToCreate.sort(startingSequenceNumberComparator);
+        return newLeasesToCreate;
+    }
+
+    /**
+     * Helper method to create leases. For an empty lease table, we will be creating leases for all shards
+     * regardless of if they are open or closed. Closed shards will be unblocked via child shard information upon
+     * reaching SHARD_END.
+     */
+    private List<KinesisClientLease> getLeasesToCreateForOpenAndClosedShards(
+            InitialPositionInStreamExtended initialPosition,
+            List<Shard> shards) {
+
+        final Map<String, Lease> shardIdToNewLeaseMap = new HashMap<>();
+
+        for (Shard shard : shards) {
+            final String shardId = shard.getShardId();
+            final KinesisClientLease lease = KinesisShardSyncer.newKCLLease(shard);
+
+            final ExtendedSequenceNumber checkpoint = KinesisShardSyncer.convertToCheckpoint(initialPosition);
+            lease.setCheckpoint(checkpoint);
+
+            LOG.debug("Need to create a lease for shard with shardId " + shardId);
+            shardIdToNewLeaseMap.put(shardId, lease);
+        }
+
+        return new ArrayList(shardIdToNewLeaseMap.values());
+    }
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardSyncer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardSyncer.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.amazonaws.services.kinesis.leases.impl.Lease;
+import com.amazonaws.services.kinesis.leases.impl.LeaseManager;
 import com.amazonaws.services.kinesis.model.ShardFilter;
 import com.amazonaws.services.kinesis.model.ShardFilterType;
 import com.amazonaws.util.CollectionUtils;
@@ -44,6 +46,8 @@ import com.amazonaws.services.kinesis.leases.interfaces.ILeaseManager;
 import com.amazonaws.services.kinesis.metrics.impl.MetricsHelper;
 import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel;
 import com.amazonaws.services.kinesis.model.Shard;
+
+import javax.annotation.Nullable;
 
 /**
  * Helper class to sync leases with shards of the Kinesis stream.
@@ -111,7 +115,7 @@ class KinesisShardSyncer implements ShardSyncer {
             boolean cleanupLeasesOfCompletedShards, boolean ignoreUnexpectedChildShards, List<Shard> latestShards)
             throws DependencyException, InvalidStateException, ProvisionedThroughputException,
             KinesisClientLibIOException {
-        syncShardLeases(kinesisProxy, leaseManager, initialPositionInStream, cleanupLeasesOfCompletedShards, ignoreUnexpectedChildShards, latestShards);
+        syncShardLeases(kinesisProxy, leaseManager, initialPositionInStream, cleanupLeasesOfCompletedShards, ignoreUnexpectedChildShards, latestShards, null);
     }
 
     /**
@@ -136,11 +140,12 @@ class KinesisShardSyncer implements ShardSyncer {
         // In the case where the lease table is empty, we want to synchronize the minimal amount of shards possible
         // based on the given initial position.
         // TODO: Implement shard list filtering on non-empty lease table case
-        final List<Shard> latestShards = leaseManager.isLeaseTableEmpty()
+        final boolean isLeaseTableEmpty = leaseManager.isLeaseTableEmpty();
+        final List<Shard> latestShards = isLeaseTableEmpty
                 ? getShardListAtInitialPosition(kinesisProxy, initialPosition)
                 : getCompleteShardList(kinesisProxy);
 
-        syncShardLeases(kinesisProxy, leaseManager, initialPosition, cleanupLeasesOfCompletedShards, ignoreUnexpectedChildShards, latestShards);
+        syncShardLeases(kinesisProxy, leaseManager, initialPosition, cleanupLeasesOfCompletedShards, ignoreUnexpectedChildShards, latestShards, isLeaseTableEmpty);
     }
 
     /**
@@ -159,10 +164,15 @@ class KinesisShardSyncer implements ShardSyncer {
      */
     // CHECKSTYLE:OFF CyclomaticComplexity
     private synchronized void syncShardLeases(IKinesisProxy kinesisProxy,
-            ILeaseManager<KinesisClientLease> leaseManager, InitialPositionInStreamExtended initialPosition,
-            boolean cleanupLeasesOfCompletedShards, boolean ignoreUnexpectedChildShards, List<Shard> latestShards)
+                                              ILeaseManager<KinesisClientLease> leaseManager,
+                                              InitialPositionInStreamExtended initialPosition,
+                                              boolean cleanupLeasesOfCompletedShards,
+                                              boolean ignoreUnexpectedChildShards,
+                                              List<Shard> latestShards,
+                                              Boolean isLeaseTableEmpty)
             throws DependencyException, InvalidStateException, ProvisionedThroughputException,
             KinesisClientLibIOException {
+
         List<Shard> shards;
         if(CollectionUtils.isNullOrEmpty(latestShards)) {
             shards = getCompleteShardList(kinesisProxy);
@@ -178,11 +188,14 @@ class KinesisShardSyncer implements ShardSyncer {
             assertAllParentShardsAreClosed(inconsistentShardIds);
         }
 
-        List<KinesisClientLease> currentLeases = leaseManager.listLeases();
+        // Determine which lease sync strategy to use based on the state of the lease table
+        final LeaseSynchronizer leaseSynchronizer = getLeaseSynchronizer(isLeaseTableEmpty, leaseManager);
 
-        List<KinesisClientLease> newLeasesToCreate = determineNewLeasesToCreate(shards, currentLeases, initialPosition,
-                inconsistentShardIds);
+        List<KinesisClientLease> currentLeases = leaseManager.listLeases();
+        List<KinesisClientLease> newLeasesToCreate = determineNewLeasesToCreate(leaseSynchronizer, shards,
+                currentLeases, initialPosition, inconsistentShardIds);
         LOG.debug("Num new leases to create: " + newLeasesToCreate.size());
+
         for (KinesisClientLease lease : newLeasesToCreate) {
             long startTimeMillis = System.currentTimeMillis();
             boolean success = false;
@@ -402,45 +415,32 @@ class KinesisShardSyncer implements ShardSyncer {
     }
 
     /**
+     * Determine lease synchronization strategy based on the state of the lease table. If isLeaseTableEmpty is passed
+     * in directly, use that as source of truth. Otherwise, fallback to leaseManager's report of lease table state.
+     * The reason for the isLeaseTableEmpty bypass is to avoid any race conditions that could arise from checking
+     * leaseManager's state multiple times in a single shard sync. The state at the beginning of the shard sync
+     * should be consistent throughout the shard sync operation.
+     *
+     * @param isLeaseTableEmpty nullable Boolean (null if caller has no opinion on current state of lease table)
+     * @param leaseManager holds state of lease table
+     */
+    private LeaseSynchronizer getLeaseSynchronizer(@Nullable Boolean isLeaseTableEmpty,
+                                                   ILeaseManager<KinesisClientLease> leaseManager)
+            throws DependencyException, InvalidStateException, ProvisionedThroughputException {
+
+        if (isLeaseTableEmpty == null) {
+            isLeaseTableEmpty = leaseManager.isLeaseTableEmpty();
+        }
+
+        return isLeaseTableEmpty ? new EmptyLeaseTableSynchronizer() : new NonEmptyLeaseTableSynchronizer();
+    }
+
+    /**
      * Determine new leases to create and their initial checkpoint.
      * Note: Package level access only for testing purposes.
      *
-     * For each open (no ending sequence number) shard without open parents that doesn't already have a lease,
-     * determine if it is a descendent of any shard which is or will be processed (e.g. for which a lease exists):
-     * If so, set checkpoint of the shard to TrimHorizon and also create leases for ancestors if needed.
-     * If not, set checkpoint of the shard to the initial position specified by the client.
-     * To check if we need to create leases for ancestors, we use the following rules:
-     *   * If we began (or will begin) processing data for a shard, then we must reach end of that shard before
-     *         we begin processing data from any of its descendants.
-     *   * A shard does not start processing data until data from all its parents has been processed.
-     * Note, if the initial position is LATEST and a shard has two parents and only one is a descendant - we'll create
-     * leases corresponding to both the parents - the parent shard which is not a descendant will have
-     * its checkpoint set to Latest.
-     *
-     * We assume that if there is an existing lease for a shard, then either:
-     *   * we have previously created a lease for its parent (if it was needed), or
-     *   * the parent shard has expired.
-     *
-     * For example:
-     * Shard structure (each level depicts a stream segment):
-     * 0 1 2 3 4   5   - shards till epoch 102
-     * \ / \ / |   |
-     *  6   7  4   5   - shards from epoch 103 - 205
-     *   \ /   |  / \
-     *    8    4 9  10 - shards from epoch 206 (open - no ending sequenceNumber)
-     * Current leases: (3, 4, 5)
-     * New leases to create: (2, 6, 7, 8, 9, 10)
-     *
-     * The leases returned are sorted by the starting sequence number - following the same order
-     * when persisting the leases in DynamoDB will ensure that we recover gracefully if we fail
-     * before creating all the leases.
-     *
-     * If a shard has no existing lease, is open, and is a descendant of a parent which is still open, we ignore it
-     * here; this happens when the list of shards is inconsistent, which could be due to pagination delay for very
-     * high shard count streams (i.e., dynamodb streams for tables with thousands of partitions).  This can only
-     * currently happen here if ignoreUnexpectedChildShards was true in syncShardleases.
-     *
-     *
+     * @param leaseSynchronizer determines the strategy to use when updating leases based on the current state of
+     *        the lease table (empty vs. non-empty)
      * @param shards List of all shards in Kinesis (we'll create new leases based on this set)
      * @param currentLeases List of current leases
      * @param initialPosition One of LATEST, TRIM_HORIZON, or AT_TIMESTAMP. We'll start fetching records from that
@@ -448,85 +448,27 @@ class KinesisShardSyncer implements ShardSyncer {
      * @param inconsistentShardIds Set of child shard ids having open parents.
      * @return List of new leases to create sorted by starting sequenceNumber of the corresponding shard
      */
-    List<KinesisClientLease> determineNewLeasesToCreate(List<Shard> shards, List<KinesisClientLease> currentLeases,
-            InitialPositionInStreamExtended initialPosition, Set<String> inconsistentShardIds) {
-        Map<String, KinesisClientLease> shardIdToNewLeaseMap = new HashMap<String, KinesisClientLease>();
-        Map<String, Shard> shardIdToShardMapOfAllKinesisShards = constructShardIdToShardMap(shards);
+    List<KinesisClientLease> determineNewLeasesToCreate(LeaseSynchronizer leaseSynchronizer,
+                                                        List<Shard> shards,
+                                                        List<KinesisClientLease> currentLeases,
+                                                        InitialPositionInStreamExtended initialPosition,
+                                                        Set<String> inconsistentShardIds) {
 
-        Set<String> shardIdsOfCurrentLeases = new HashSet<String>();
-        for (KinesisClientLease lease : currentLeases) {
-            shardIdsOfCurrentLeases.add(lease.getLeaseKey());
-            LOG.debug("Existing lease: " + lease);
-        }
-
-        List<Shard> openShards = getOpenShards(shards);
-        Map<String, Boolean> memoizationContext = new HashMap<>();
-
-        // Iterate over the open shards and find those that don't have any lease entries.
-        for (Shard shard : openShards) {
-            String shardId = shard.getShardId();
-            LOG.debug("Evaluating leases for open shard " + shardId + " and its ancestors.");
-            if (shardIdsOfCurrentLeases.contains(shardId)) {
-                LOG.debug("Lease for shardId " + shardId + " already exists. Not creating a lease");
-            } else if (inconsistentShardIds.contains(shardId)) {
-                LOG.info("shardId " + shardId + " is an inconsistent child.  Not creating a lease");
-            } else {
-                LOG.debug("Need to create a lease for shardId " + shardId);
-                KinesisClientLease newLease = newKCLLease(shard);
-                boolean isDescendant = checkIfDescendantAndAddNewLeasesForAncestors(shardId, initialPosition,
-                        shardIdsOfCurrentLeases, shardIdToShardMapOfAllKinesisShards, shardIdToNewLeaseMap,
-                        memoizationContext);
-
-                /**
-                 * If the shard is a descendant and the specified initial position is AT_TIMESTAMP, then the
-                 * checkpoint should be set to AT_TIMESTAMP, else to TRIM_HORIZON. For AT_TIMESTAMP, we will add a
-                 * lease just like we do for TRIM_HORIZON. However we will only return back records with server-side
-                 * timestamp at or after the specified initial position timestamp.
-                 *
-                 * Shard structure (each level depicts a stream segment):
-                 * 0 1 2 3 4   5   - shards till epoch 102
-                 * \ / \ / |   |
-                 *  6   7  4   5   - shards from epoch 103 - 205
-                 *   \ /   |  /\
-                 *    8    4 9  10 - shards from epoch 206 (open - no ending sequenceNumber)
-                 *
-                 * Current leases: empty set
-                 *
-                 * For the above example, suppose the initial position in stream is set to AT_TIMESTAMP with
-                 * timestamp value 206. We will then create new leases for all the shards (with checkpoint set to
-                 * AT_TIMESTAMP), including the ancestor shards with epoch less than 206. However as we begin
-                 * processing the ancestor shards, their checkpoints would be updated to SHARD_END and their leases
-                 * would then be deleted since they won't have records with server-side timestamp at/after 206. And
-                 * after that we will begin processing the descendant shards with epoch at/after 206 and we will
-                 * return the records that meet the timestamp requirement for these shards.
-                 */
-                if (isDescendant && !initialPosition.getInitialPositionInStream()
-                        .equals(InitialPositionInStream.AT_TIMESTAMP)) {
-                    newLease.setCheckpoint(ExtendedSequenceNumber.TRIM_HORIZON);
-                } else {
-                    newLease.setCheckpoint(convertToCheckpoint(initialPosition));
-                }
-                LOG.debug("Set checkpoint of " + newLease.getLeaseKey() + " to " + newLease.getCheckpoint());
-                shardIdToNewLeaseMap.put(shardId, newLease);
-            }
-        }
-
-        List<KinesisClientLease> newLeasesToCreate = new ArrayList<KinesisClientLease>();
-        newLeasesToCreate.addAll(shardIdToNewLeaseMap.values());
-        Comparator<? super KinesisClientLease> startingSequenceNumberComparator = new StartingSequenceNumberAndShardIdBasedComparator(
-                shardIdToShardMapOfAllKinesisShards);
-        Collections.sort(newLeasesToCreate, startingSequenceNumberComparator);
-        return newLeasesToCreate;
+        return leaseSynchronizer.determineNewLeasesToCreate(shards, currentLeases, initialPosition,
+                inconsistentShardIds);
     }
 
     /**
      * Determine new leases to create and their initial checkpoint.
      * Note: Package level access only for testing purposes.
      */
-    List<KinesisClientLease> determineNewLeasesToCreate(List<Shard> shards, List<KinesisClientLease> currentLeases,
-            InitialPositionInStreamExtended initialPosition) {
+    List<KinesisClientLease> determineNewLeasesToCreate(LeaseSynchronizer leaseSynchronizer,
+                                                        List<Shard> shards,
+                                                        List<KinesisClientLease> currentLeases,
+                                                        InitialPositionInStreamExtended initialPosition) {
+
         Set<String> inconsistentShardIds = new HashSet<String>();
-        return determineNewLeasesToCreate(shards, currentLeases, initialPosition, inconsistentShardIds);
+        return determineNewLeasesToCreate(leaseSynchronizer, shards, currentLeases, initialPosition, inconsistentShardIds);
     }
 
     /**
@@ -794,7 +736,7 @@ class KinesisShardSyncer implements ShardSyncer {
      * @param shard
      * @return
      */
-    KinesisClientLease newKCLLease(Shard shard) {
+    static KinesisClientLease newKCLLease(Shard shard) {
         KinesisClientLease newLease = new KinesisClientLease();
         newLease.setLeaseKey(shard.getShardId());
         List<String> parentShardIds = new ArrayList<String>(2);
@@ -816,7 +758,7 @@ class KinesisShardSyncer implements ShardSyncer {
      * @param shards List of shards
      * @return ShardId->Shard map
      */
-    Map<String, Shard> constructShardIdToShardMap(List<Shard> shards) {
+    static Map<String, Shard> constructShardIdToShardMap(List<Shard> shards) {
         Map<String, Shard> shardIdToShardMap = new HashMap<String, Shard>();
         for (Shard shard : shards) {
             shardIdToShardMap.put(shard.getShardId(), shard);
@@ -843,7 +785,7 @@ class KinesisShardSyncer implements ShardSyncer {
         return openShards;
     }
 
-    private ExtendedSequenceNumber convertToCheckpoint(InitialPositionInStreamExtended position) {
+    static ExtendedSequenceNumber convertToCheckpoint(InitialPositionInStreamExtended position) {
         ExtendedSequenceNumber checkpoint = null;
 
         if (position.getInitialPositionInStream().equals(InitialPositionInStream.TRIM_HORIZON)) {
@@ -860,7 +802,7 @@ class KinesisShardSyncer implements ShardSyncer {
     /** Helper class to compare leases based on starting sequence number of the corresponding shards.
      *
      */
-    private static class StartingSequenceNumberAndShardIdBasedComparator implements Comparator<KinesisClientLease>,
+    static class StartingSequenceNumberAndShardIdBasedComparator implements Comparator<KinesisClientLease>,
             Serializable {
 
         private static final long serialVersionUID = 1L;

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/LeaseSynchronizer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/LeaseSynchronizer.java
@@ -1,0 +1,27 @@
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+import com.amazonaws.services.kinesis.model.Shard;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Interface used by {@link KinesisShardSyncer} to determine how to create new leases based on the current state
+ * of the lease table (i.e. whether the lease table is empty or non-empty).
+ */
+interface LeaseSynchronizer {
+
+    /**
+     * Determines how to create leases.
+     * @param shards
+     * @param currentLeases
+     * @param initialPosition
+     * @param inconsistentShardIds
+     * @return
+     */
+    List<KinesisClientLease> determineNewLeasesToCreate(List<Shard> shards,
+                                                        List<KinesisClientLease> currentLeases,
+                                                        InitialPositionInStreamExtended initialPosition,
+                                                        Set<String> inconsistentShardIds);
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/NonEmptyLeaseTableSynchronizer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/NonEmptyLeaseTableSynchronizer.java
@@ -1,0 +1,146 @@
+package com.amazonaws.services.kinesis.clientlibrary.lib.worker;
+
+import com.amazonaws.services.kinesis.clientlibrary.types.ExtendedSequenceNumber;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
+import com.amazonaws.services.kinesis.leases.impl.Lease;
+import com.amazonaws.services.kinesis.model.Shard;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * TODO - non-empty lease table sync story
+ */
+class NonEmptyLeaseTableSynchronizer implements LeaseSynchronizer {
+
+//    private final ShardDetector shardDetector;
+//    private final Map<String, Shard> shardIdToShardMap;
+//    private final Map<String, Set<String>> shardIdToChildShardIdsMap;
+
+    /**
+     * Determine new leases to create and their initial checkpoint.
+     * Note: Package level access only for testing purposes.
+     *
+     * For each open (no ending sequence number) shard without open parents that doesn't already have a lease,
+     * determine if it is a descendent of any shard which is or will be processed (e.g. for which a lease exists):
+     * If so, set checkpoint of the shard to TrimHorizon and also create leases for ancestors if needed.
+     * If not, set checkpoint of the shard to the initial position specified by the client.
+     * To check if we need to create leases for ancestors, we use the following rules:
+     *   * If we began (or will begin) processing data for a shard, then we must reach end of that shard before
+     *         we begin processing data from any of its descendants.
+     *   * A shard does not start processing data until data from all its parents has been processed.
+     * Note, if the initial position is LATEST and a shard has two parents and only one is a descendant - we'll create
+     * leases corresponding to both the parents - the parent shard which is not a descendant will have
+     * its checkpoint set to Latest.
+     *
+     * We assume that if there is an existing lease for a shard, then either:
+     *   * we have previously created a lease for its parent (if it was needed), or
+     *   * the parent shard has expired.
+     *
+     * For example:
+     * Shard structure (each level depicts a stream segment):
+     * 0 1 2 3 4   5   - shards till epoch 102
+     * \ / \ / |   |
+     *  6   7  4   5   - shards from epoch 103 - 205
+     *   \ /   |  / \
+     *    8    4 9  10 - shards from epoch 206 (open - no ending sequenceNumber)
+     * Current leases: (3, 4, 5)
+     * New leases to create: (2, 6, 7, 8, 9, 10)
+     *
+     * The leases returned are sorted by the starting sequence number - following the same order
+     * when persisting the leases in DynamoDB will ensure that we recover gracefully if we fail
+     * before creating all the leases.
+     *
+     * If a shard has no existing lease, is open, and is a descendant of a parent which is still open, we ignore it
+     * here; this happens when the list of shards is inconsistent, which could be due to pagination delay for very
+     * high shard count streams (i.e., dynamodb streams for tables with thousands of partitions).  This can only
+     * currently happen here if ignoreUnexpectedChildShards was true in syncShardleases.
+     *
+     * @param shards List of all shards in Kinesis (we'll create new leases based on this set)
+     * @param currentLeases List of current leases
+     * @param initialPosition One of LATEST, TRIM_HORIZON, or AT_TIMESTAMP. We'll start fetching records from that
+     *        location in the shard (when an application starts up for the first time - and there are no checkpoints).
+     * @param inconsistentShardIds Set of child shard ids having open parents.
+     * @return List of new leases to create sorted by starting sequenceNumber of the corresponding shard
+     */
+    @Override
+    public List<KinesisClientLease> determineNewLeasesToCreate(List<Shard> shards,
+                                                               List<KinesisClientLease> currentLeases,
+                                                               InitialPositionInStreamExtended initialPosition,
+                                                               Set<String> inconsistentShardIds) {
+        return null;
+//        Map<String, KinesisClientLease> shardIdToNewLeaseMap = new HashMap<String, KinesisClientLease>();
+//        Map<String, Shard> shardIdToShardMapOfAllKinesisShards = constructShardIdToShardMap(shards);
+//
+//        Set<String> shardIdsOfCurrentLeases = new HashSet<String>();
+//        for (Lease lease : currentLeases) {
+//            shardIdsOfCurrentLeases.add(lease.getLeaseKey());
+//            LOG.debug("Existing lease: " + lease);
+//        }
+//
+//        List<Shard> openShards = getOpenShards(shards);
+//        Map<String, Boolean> memoizationContext = new HashMap<>();
+//
+//        // Iterate over the open shards and find those that don't have any lease entries.
+//        for (Shard shard : openShards) {
+//            String shardId = shard.getShardId();
+//            LOG.debug("Evaluating leases for open shard " + shardId + " and its ancestors.");
+//            if (shardIdsOfCurrentLeases.contains(shardId)) {
+//                LOG.debug("Lease for shardId " + shardId + " already exists. Not creating a lease");
+//            } else if (inconsistentShardIds.contains(shardId)) {
+//                LOG.info("shardId " + shardId + " is an inconsistent child.  Not creating a lease");
+//            } else {
+//                LOG.debug("Need to create a lease for shardId " + shardId);
+//                KinesisClientLease newLease = newKCLLease(shard);
+//                boolean isDescendant = checkIfDescendantAndAddNewLeasesForAncestors(shardId, initialPosition,
+//                        shardIdsOfCurrentLeases, shardIdToShardMapOfAllKinesisShards, shardIdToNewLeaseMap,
+//                        memoizationContext);
+//
+//                /**
+//                 * If the shard is a descendant and the specified initial position is AT_TIMESTAMP, then the
+//                 * checkpoint should be set to AT_TIMESTAMP, else to TRIM_HORIZON. For AT_TIMESTAMP, we will add a
+//                 * lease just like we do for TRIM_HORIZON. However we will only return back records with server-side
+//                 * timestamp at or after the specified initial position timestamp.
+//                 *
+//                 * Shard structure (each level depicts a stream segment):
+//                 * 0 1 2 3 4   5   - shards till epoch 102
+//                 * \ / \ / |   |
+//                 *  6   7  4   5   - shards from epoch 103 - 205
+//                 *   \ /   |  /\
+//                 *    8    4 9  10 - shards from epoch 206 (open - no ending sequenceNumber)
+//                 *
+//                 * Current leases: empty set
+//                 *
+//                 * For the above example, suppose the initial position in stream is set to AT_TIMESTAMP with
+//                 * timestamp value 206. We will then create new leases for all the shards (with checkpoint set to
+//                 * AT_TIMESTAMP), including the ancestor shards with epoch less than 206. However as we begin
+//                 * processing the ancestor shards, their checkpoints would be updated to SHARD_END and their leases
+//                 * would then be deleted since they won't have records with server-side timestamp at/after 206. And
+//                 * after that we will begin processing the descendant shards with epoch at/after 206 and we will
+//                 * return the records that meet the timestamp requirement for these shards.
+//                 */
+//                if (isDescendant && !initialPosition.getInitialPositionInStream()
+//                        .equals(InitialPositionInStream.AT_TIMESTAMP)) {
+//                    newLease.setCheckpoint(ExtendedSequenceNumber.TRIM_HORIZON);
+//                } else {
+//                    newLease.setCheckpoint(convertToCheckpoint(initialPosition));
+//                }
+//                LOG.debug("Set checkpoint of " + newLease.getLeaseKey() + " to " + newLease.getCheckpoint());
+//                shardIdToNewLeaseMap.put(shardId, newLease);
+//            }
+//        }
+//
+//        List<KinesisClientLease> newLeasesToCreate = new ArrayList<KinesisClientLease>();
+//        newLeasesToCreate.addAll(shardIdToNewLeaseMap.values());
+//        Comparator<? super KinesisClientLease> startingSequenceNumberComparator = new KinesisShardSyncer.StartingSequenceNumberAndShardIdBasedComparator(
+//                shardIdToShardMapOfAllKinesisShards);
+//        Collections.sort(newLeasesToCreate, startingSequenceNumberComparator);
+//        return newLeasesToCreate;
+    }
+}

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/IKinesisProxy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/IKinesisProxy.java
@@ -26,6 +26,7 @@ import com.amazonaws.services.kinesis.model.InvalidArgumentException;
 import com.amazonaws.services.kinesis.model.PutRecordResult;
 import com.amazonaws.services.kinesis.model.ResourceNotFoundException;
 import com.amazonaws.services.kinesis.model.Shard;
+import com.amazonaws.services.kinesis.model.ShardFilter;
 
 /**
  * Kinesis proxy interface. Operates on a single stream (set up at initialization).
@@ -77,6 +78,17 @@ public interface IKinesisProxy {
      * @throws ResourceNotFoundException The Kinesis stream was not found.
      */
     List<Shard> getShardList() throws ResourceNotFoundException;
+
+    /**
+     * Fetch a subset shards defined for the stream using a filter on the ListShards API. This can be used to
+     * discover new shards and consume data from them, while limiting the total number of shards returned for
+     * performance or efficiency reasons.
+     *
+     * @param shardFilter currently supported filter types are AT_LATEST, AT_TRIM_HORIZON, AT_TIMESTAMP.
+     * @return List of all shards in the Kinesis stream.
+     * @throws ResourceNotFoundException The Kinesis stream was not found.
+     */
+    List<Shard> getShardListWithFilter(ShardFilter shardFilter) throws ResourceNotFoundException;
 
     /**
      * Used to verify during ShardConsumer shutdown if the provided shardId is for a shard that has been closed.

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/MetricsCollectingKinesisProxyDecorator.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/proxies/MetricsCollectingKinesisProxyDecorator.java
@@ -28,6 +28,7 @@ import com.amazonaws.services.kinesis.model.ResourceNotFoundException;
 import com.amazonaws.services.kinesis.model.Shard;
 import com.amazonaws.services.kinesis.metrics.impl.MetricsHelper;
 import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel;
+import com.amazonaws.services.kinesis.model.ShardFilter;
 
 /**
  * IKinesisProxy implementation that wraps another implementation and collects metrics.
@@ -172,6 +173,22 @@ public class MetricsCollectingKinesisProxyDecorator implements IKinesisProxy {
         boolean success = false;
         try {
             List<Shard> response = other.getShardList();
+            success = true;
+            return response;
+        } finally {
+            MetricsHelper.addSuccessAndLatency(getShardListMetric, startTime, success, MetricsLevel.DETAILED);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Shard> getShardListWithFilter(ShardFilter shardFilter) throws ResourceNotFoundException {
+        long startTime = System.currentTimeMillis();
+        boolean success = false;
+        try {
+            List<Shard> response = other.getShardListWithFilter(shardFilter);
             success = true;
             return response;
         } finally {

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/proxies/KinesisLocalFileProxy.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/proxies/KinesisLocalFileProxy.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.amazonaws.services.kinesis.model.ShardFilter;
 import com.amazonaws.util.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -420,6 +421,16 @@ public class KinesisLocalFileProxy implements IKinesisProxy {
      */
     @Override
     public List<Shard> getShardList() throws ResourceNotFoundException {
+        List<Shard> shards = new LinkedList<Shard>();
+        shards.addAll(shardList);
+        return shards;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Shard> getShardListWithFilter(ShardFilter shardFilter) throws ResourceNotFoundException {
         List<Shard> shards = new LinkedList<Shard>();
         shards.addAll(shardList);
         return shards;


### PR DESCRIPTION
Initial draft PR for using new ListShardsWithFilter API in all implementation of IKinesisProxy in KCL 1.x. Will add tests in subsequent PRs and/or revisions.

Still need to implement new lease creation strategy for empty lease table, but will do that in a separate PR to keep the diff small.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
